### PR TITLE
Fix #1: can't add a new key during iteration

### DIFF
--- a/lib/bayes_motel/corpus.rb
+++ b/lib/bayes_motel/corpus.rb
@@ -76,7 +76,7 @@ module BayesMotel
     def clean(hash, k, v)
       case v
       when Hash
-        v.each_pair do |key, value|
+        v.to_a.each do |key, value|
           clean(v, key, value)
         end
         if v.empty?


### PR DESCRIPTION
In Ruby 1.8, you could insert into hashes while iterating, but since 1.9 uses ordered hashes, this results in a RuntimeError. The simple fix is to convert the hash to an array before iteration.

This change is from http://stackoverflow.com/a/11120147/73492, but it was never reported back to the project.
