### PR TITLE
Update development environment for 1.9

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ rdoc
 pkg
 
 ## PROJECT::SPECIFIC
+Gemfile.lock

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source 'https://rubygems.org'
+
+gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -10,19 +10,6 @@ end
 
 task :default => :test
 
-begin
-  require 'rcov/rcovtask'
-  Rcov::RcovTask.new do |test|
-    test.libs << 'test'
-    test.pattern = 'test/**/test_*.rb'
-    test.verbose = true
-  end
-rescue LoadError
-  task :rcov do
-    abort "RCov is not available. In order to run rcov, you must: sudo gem install spicycode-rcov"
-  end
-end
-
 Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title = "bayes_motel #{BayesMotel::VERSION}"

--- a/Rakefile
+++ b/Rakefile
@@ -1,25 +1,4 @@
-require 'rubygems'
-require 'rake'
-require 'lib/bayes_motel/version'
-
-begin
-  require 'jeweler'
-  Jeweler::Tasks.new do |gem|
-    gem.name = "bayes_motel"
-    gem.summary = %Q{Bayesian classification engine}
-    gem.description = %Q{http://www.mikeperham.com/2010/04/28/bayes_motel-bayesian-classification-for-ruby/}
-    gem.email = "mperham@gmail.com"
-    gem.homepage = "http://github.com/mperham/bayes_motel"
-    gem.authors = ["Mike Perham"]
-    gem.version = BayesMotel::VERSION
-    gem.add_development_dependency "shoulda", ">= 0"
-    # gem is a Gem::Specification... see http://www.rubygems.org/read/chapter/20 for additional settings
-  end
-  Jeweler::GemcutterTasks.new
-rescue LoadError
-  puts "Jeweler (or a dependency) not available. Install it with: gem install jeweler"
-end
-
+require 'bundler/gem_tasks'
 require 'rake/testtask'
 Rake::TestTask.new(:test) do |test|
   test.libs << 'lib' << 'test'
@@ -39,8 +18,6 @@ rescue LoadError
     abort "RCov is not available. In order to run rcov, you must: sudo gem install spicycode-rcov"
   end
 end
-
-task :test => :check_dependencies
 
 task :default => :test
 

--- a/Rakefile
+++ b/Rakefile
@@ -1,10 +1,14 @@
 require 'bundler/gem_tasks'
 require 'rake/testtask'
+require 'rdoc/task'
+
 Rake::TestTask.new(:test) do |test|
-  test.libs << 'lib' << 'test'
+  test.libs << 'test'
   test.pattern = 'test/**/test_*.rb'
   test.verbose = true
 end
+
+task :default => :test
 
 begin
   require 'rcov/rcovtask'
@@ -19,9 +23,6 @@ rescue LoadError
   end
 end
 
-task :default => :test
-
-require 'rake/rdoctask'
 Rake::RDocTask.new do |rdoc|
   rdoc.rdoc_dir = 'rdoc'
   rdoc.title = "bayes_motel #{BayesMotel::VERSION}"

--- a/bayes_motel.gemspec
+++ b/bayes_motel.gemspec
@@ -17,5 +17,6 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_development_dependency "rake", "~> 10.0"
-  gem.add_development_dependency "shoulda", ">= 0"
+  gem.add_development_dependency "shoulda", ">= 3.4"
+  gem.add_development_dependency "simplecov", ">= 0.7"
 end

--- a/bayes_motel.gemspec
+++ b/bayes_motel.gemspec
@@ -1,0 +1,21 @@
+lib = File.expand_path('../lib', __FILE__)
+$LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
+
+require 'bayes_motel'
+
+Gem::Specification.new do |gem|
+  gem.name          = "bayes_motel"
+  gem.summary       = %Q{Bayesian classification engine}
+  gem.description   = %Q{http://www.mikeperham.com/2010/04/28/bayes_motel-bayesian-classification-for-ruby/}
+  gem.email         = "mperham@gmail.com"
+  gem.homepage      = "http://github.com/mperham/bayes_motel"
+  gem.authors       = ["Mike Perham"]
+  gem.version       = BayesMotel::VERSION
+  gem.files         = `git ls-files`.split($/)
+  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.require_paths = ["lib"]
+
+  gem.add_development_dependency "rake", "~> 10.0"
+  gem.add_development_dependency "shoulda", ">= 0"
+end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -1,11 +1,12 @@
 require 'rubygems'
-require 'test/unit'
 require 'shoulda'
+require 'simplecov'
+require 'test/unit'
 require 'zlib'
 
 $LOAD_PATH.unshift(File.join(File.dirname(__FILE__), '..', 'lib'))
 $LOAD_PATH.unshift(File.dirname(__FILE__))
-require 'bayes_motel'
 
-class Test::Unit::TestCase
-end
+SimpleCov.start
+
+require 'bayes_motel'


### PR DESCRIPTION
Here are a few patches to make developing the gem on 1.9+ possible. These patches fix the deprecated Rdoc Rake task, replace Rcov with Simplecov, and replace Jeweler with Bundler (and add the development dependencies too).

Tested in 1.9.3 and 2.0. (The unit tests will error out until #1 is fixed.)
